### PR TITLE
Release: v0.3.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
 
   release:
     docker:
-      - image: novopl/python37
+      - image: novopl/python:3.8-dev
     steps:
       - checkout
       - restore_cache:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool]
 [tool.poetry]
 name = "jwtlib"
-version = "0.3.0"
+version = "0.3.1"
 description = "A little helper library to streamline working with JWT in python"
 readme = "README.rst"
 repository = "http://github.com/novopl/jwtlib"
@@ -61,6 +61,7 @@ omit = []
 
 [tool.coverage.report]
 exclude_lines = ['nocov']
+
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/src/jwtlib/__init__.py
+++ b/src/jwtlib/__init__.py
@@ -3,4 +3,4 @@ from .abstract import UserAdapterBase  # noqa: F401
 from .main import JsonDict, JwtLib, User  # noqa: F401
 
 
-__version__ = '0.3.0'
+__version__ = '0.3.1'


### PR DESCRIPTION
v0.3.1
=======


Features
--------

- Support for account adapters
- Mark the library as typed.


Changes
-------

- Bump PyJWT version to 2.4.0
- Remove flask adapter
- Move flask adapter to the adapters package
- The default header prefix is now 'Bearer'
- Rename the main class from Jwt to JwtLib
- Remove status code from exception class.


Dev tasks
---------

- A few helper scripts to manage releases
- Make CI builds use python 3.8
- Update peltak to the latest version
- Update dependencies to the latest version
- Add tests